### PR TITLE
Using SQL as ace mode

### DIFF
--- a/lib/metadata_hook.rb
+++ b/lib/metadata_hook.rb
@@ -6,7 +6,7 @@ class SqliteMetadataHook < Mumukit::Hook
         icon: { type: 'devicon', name: 'sqlite' },
         version: 'v0.2.2',
         extension: 'sql',
-        ace_mode: 'assembly_x86',
+        ace_mode: 'sql',
         graphic: true
       },
       test_framework: {


### PR DESCRIPTION
Setting `ace_mode` enables color highlight when using this runner within mumuki platform.