### PR TITLE
Adding Version hook

### DIFF
--- a/lib/sqlite_runner.rb
+++ b/lib/sqlite_runner.rb
@@ -10,6 +10,7 @@ Mumukit.configure do |config|
   config.structured = true
 end
 
+require_relative './version_hook'
 require_relative './test_hook'
 require_relative './metadata_hook'
 require_relative './checker'

--- a/lib/version_hook.rb
+++ b/lib/version_hook.rb
@@ -1,0 +1,3 @@
+module SqliteVersionHook
+  VERSION = '0.1'
+end

--- a/mumuki-sqlite-runner.gemspec
+++ b/mumuki-sqlite-runner.gemspec
@@ -1,10 +1,12 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'version_hook'
+
 
 Gem::Specification.new do |spec|
   spec.name          = 'mumuki-sqlite-runner'
-  spec.version       = '0.1'
+  spec.version       = SqliteVersionHook::VERSION
   spec.authors       = ['Leandro Di Lorenzo']
   spec.email         = ['leandro.jdl@gmail.com']
   spec.summary       = 'SQLite Runner for Mumuki'


### PR DESCRIPTION
I am adding a version hook, which enables mumuki platform to  consume runner's version though `/info` endpoint: 

```json
{
   "version" : "0.1",
   "url" : "http://localhost:9292/info",
   "test_framework" : {
      "name" : "metatest",
      "test_extension" : "yml"
   },
   "escualo_base_version" : null,
   "features" : {
      "sandboxed" : true,
      "feedback" : false,
      "secure" : false,
      "expectations" : false,
      "query" : false,
      "preprocessor" : true,
      "stateful" : false,
      "structured" : true
   },
   "mumukit_version" : "2.8.0",
   "comment_type" : "cpp",
   "escualo_service_version" : null,
   "language" : {
      "name" : "sqlite",
      "graphic" : true,
      "extension" : "sql",
      "icon" : {
         "type" : "devicon",
         "name" : "sqlite"
      },
      "ace_mode" : "sql",
      "version" : "v0.2.2"
   },
   "output_content_type" : "plain",
   "name" : "sqlite"
}
```  